### PR TITLE
Updated Polish translation

### DIFF
--- a/src/main/resources/assets/controlling/lang/pl_pl.json
+++ b/src/main/resources/assets/controlling/lang/pl_pl.json
@@ -1,11 +1,15 @@
 {
   "options.search": "Szukaj",
-  "options.showAll": "Pokaż wszystkie",
-  "options.showConflicts": "Pokaż konflikty",
-  "options.showNone": "Pokaż nieprzypis.",
-  "options.availableKeys": "Dostępne klawisze",
-  "options.sort": "Sortowanie",
-  "options.category": "Kategorie",
-  "options.key": "Klawisze",
-  "options.toggleFree": "Pokaż/ukryj wolne"
+  "options.showAll": "Wszystkie",
+  "options.showConflicts": "Konfliktujące",
+  "options.showNone": "Nieprzypisane",
+  "options.availableKeys": "Available Keys",
+  "options.sort": "Sortow.",
+  "options.category": "Kategoria",
+  "options.key": "Klawisz",
+  "options.sortNone": "Brak",
+  "options.sortAZ": "A->Z",
+  "options.sortZA": "Z->A",
+  "options.toggleFree": "Toggle Free",
+  "options.confirmReset": "Kliknij, by potwierdzić reset!"
 }


### PR DESCRIPTION
As in the title, in this commit I updated the Polish translation.

While I was translating, I spend some time to find out where string `options.availableKeys` and `options.toggleFree` are displayed in game, but I couldn't figure it out. Is this intentional, and they are no longer used on purpose? If so, maybe consider removing them from all translation files.

Also, if you still support 1.12, I can create another PR with changes from this one, but backported to the old language files format.