### PR TITLE
Add Italian localization

### DIFF
--- a/src/main/resources/assets/controlling/lang/it_it.json
+++ b/src/main/resources/assets/controlling/lang/it_it.json
@@ -1,0 +1,15 @@
+{
+  "options.search": "Ricerca",
+  "options.showAll": "Vedi tutti",
+  "options.showConflicts": "Vedi conflitti",
+  "options.showNone": "Vedi mancanti",
+  "options.availableKeys": "Tasti disponibili",
+  "options.sort": "Ordine",
+  "options.category": "Categoria",
+  "options.key": "Tasto",
+  "options.sortNone": "no",
+  "options.sortAZ": "A->Z",
+  "options.sortZA": "Z->A",
+  "options.toggleFree": "Tasti liberi",
+  "options.confirmReset": "Conferma ripristino"
+}


### PR DESCRIPTION
Adds Italian to the list of languages supported by Controlling.

I've also noticed that some language keys are unused: I've translated them regardless, though I have been unable to check whether the text fits in the spot it has been placed in.