### PR TITLE
Fix modlist data + Catalogue Support

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,14 +1,15 @@
-modLoader="javafml" #mandatory
-loaderVersion="[34,)" #mandatory
-issueTrackerURL="https://github.com/jaredlll08/Controlling/issues" #optional
-displayURL="https://minecraft.curseforge.com/projects/controlling" #optional
-authors="Jaredlll08" #optional
+modLoader="javafml"
+loaderVersion="[34,)"
+issueTrackerURL="https://github.com/jaredlll08/Controlling/issues"
 license="MIT"
-[[mods]] #mandatory
-modId="controlling" #mandatory
-version="${file.jarVersion}" #mandatory
-displayName="Controlling" #mandatory
+
+[[mods]]
+modId="controlling"
 updateJSONURL="https://updates.blamejared.com/get?n=controlling&gv=1.16.5"
+version="${file.jarVersion}"
+displayName="Controlling"
+displayURL="https://minecraft.curseforge.com/projects/controlling"
+authors="Jaredlll08"
 description='''
 Adds the ability to search for keybinds using their name in the KeyBinding menu, this allows players to easily find a key binding in the menu.
 '''

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -13,3 +13,4 @@ authors="Jaredlll08"
 description='''
 Adds the ability to search for keybinds using their name in the KeyBinding menu, this allows players to easily find a key binding in the menu.
 '''
+itemIcon="minecraft:compass"


### PR DESCRIPTION
This PR fixes the author info and the download URL not being associated with Controlling's modId. It also adds support for the [Catalogue mod](https://www.curseforge.com/minecraft/mc-mods/catalogue)'s mod list.

![image](https://user-images.githubusercontent.com/2250798/118303368-9906e680-b4a2-11eb-8540-985090a89d6c.png)
