### PR TITLE
Include dependency definitions for Forge and Minecraft in mods.toml and specify side

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -14,3 +14,15 @@ description='''
 Adds the ability to search for keybinds using their name in the KeyBinding menu, this allows players to easily find a key binding in the menu.
 '''
 itemIcon="minecraft:compass"
+  [[dependencies.controlling]]
+    modId="forge"
+    mandatory=true
+    versionRange="[34,)"
+    ordering="NONE"
+    side="CLIENT"
+  [[dependencies.controlling]]
+    modId="minecraft"
+    mandatory=true
+    versionRange="[1.16.3,)"
+    ordering="NONE"
+    side="CLIENT"


### PR DESCRIPTION
I noticed that your mods.toml is missing the dependency definition for Forge and Minecraft.

mods.toml need to specify their sideness so Minecraft/Forge knows whether the mod needs to be available on the client, the server, or both. If a mod uses the modId for dependencies.<value_of_modId>, it also helps with ServerPackCreator identifying clientside-only mods. [Reference issue #70](https://github.com/Griefed/ServerPackCreator/issues/70) of ServerPackCreator.

Let me know what you think. 👋

Cheers,
Griefed