### PR TITLE
Prevent server-side crashing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,8 @@ archivesBaseName = 'Controlling'
 sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8'
 
 minecraft {
+    replaceIn "Controlling.java"
+    replace "GRADLETOKEN_VERSION", project.version
     version = "1.7.10-10.13.4.1614-1.7.10"
     mappings = "stable_12"
     runDir = "run"

--- a/src/main/java/com/blamejared/controlling/Controlling.java
+++ b/src/main/java/com/blamejared/controlling/Controlling.java
@@ -14,7 +14,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Mod(modid = "controlling", name = "Controlling", version = "7.0.0", acceptableRemoteVersions = "*")
+@Mod(modid = "controlling", name = "Controlling", version = "GRADLETOKEN_VERSION", acceptableRemoteVersions = "*")
 public class Controlling {
 
     public static Set<String> PATRON_LIST = new HashSet<>();

--- a/src/main/java/com/blamejared/controlling/Controlling.java
+++ b/src/main/java/com/blamejared/controlling/Controlling.java
@@ -38,6 +38,8 @@ public class Controlling {
 
     @Mod.EventHandler
     private void init(final FMLInitializationEvent event) {
-        MinecraftForge.EVENT_BUS.register(new ClientEventHandler());
+        if (event.getSide().isClient()) {
+            MinecraftForge.EVENT_BUS.register(new ClientEventHandler());
+        }
     }
 }

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -5,7 +5,7 @@
     "description": "Adds the ability to search for keybinds using their name in the KeyBinding menu, this allows players to easily find a key binding in the menu.",
     "version": "${version}",
     "mcversion": "${mcversion}",
-    "url": "https://minecraft.curseforge.com/projects/controlling",
+    "url": "https://www.curseforge.com/minecraft/mc-mods/controlling",
     "updateUrl": "",
     "authorList": ["Jaredlll08"],
     "credits": "",


### PR DESCRIPTION
Taken from https://github.com/GTNewHorizons/Controlling/commit/baf9c0a97948211d1a54f3a3d173b59a0d21111b.

If you get the error:
```
Unexpected reponse 403 from https://s3.amazonaws.com/Minecraft.Download/versions/1.7.10/1.7.10.json
```
while building, you probably need need to switch to a different fork, as anatawa12's fork doesn't seem to have fixed this yet.