### PR TITLE
Fix long description unreadable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,16 +3,16 @@ buildscript {
         jcenter()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://maven.minecraftforge.net"
         }
     }
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3.4'
     }
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "3.0.10"
+version = "3.0.11"
 group= "us.getfluxed.controlling" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "Controlling"
 
@@ -26,9 +26,9 @@ jar {
     }
 }
 minecraft {
-    version = "1.12-14.21.1.2387"
+    version = "1.12.2-14.23.5.2847"
     runDir = "run"
-    mappings = "snapshot_20161220"
+    mappings = "stable_39"
 }
 
 dependencies {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip

--- a/src/main/java/us/getfluxed/controlsearch/client/gui/GuiNewControls.java
+++ b/src/main/java/us/getfluxed/controlsearch/client/gui/GuiNewControls.java
@@ -69,15 +69,15 @@ public class GuiNewControls extends GuiControls {
         int i = 0;
         
         for(GameSettings.Options gamesettings$options : OPTIONS_ARR) {
-            if(gamesettings$options.getEnumFloat()) {
-                this.buttonList.add(new GuiOptionSlider(gamesettings$options.returnEnumOrdinal(), this.width / 2 - 155 + i % 2 * 160, 18 + 24 * (i >> 1), gamesettings$options));
+            if(gamesettings$options.isFloat()) {
+                this.buttonList.add(new GuiOptionSlider(gamesettings$options.getOrdinal(), this.width / 2 - 155 + i % 2 * 160, 18 + 24 * (i >> 1), gamesettings$options));
             } else {
-                this.buttonList.add(new GuiOptionButton(gamesettings$options.returnEnumOrdinal(), this.width / 2 - 155 + i % 2 * 160, 18 + 24 * (i >> 1), gamesettings$options, this.options.getKeyBinding(gamesettings$options)));
+                this.buttonList.add(new GuiOptionButton(gamesettings$options.getOrdinal(), this.width / 2 - 155 + i % 2 * 160, 18 + 24 * (i >> 1), gamesettings$options, this.options.getKeyBinding(gamesettings$options)));
             }
             ++i;
         }
         
-        search = new GuiTextField(0, mc.fontRendererObj, this.width / 2 - 154, this.height - 29 - 23, 148, 18);
+        search = new GuiTextField(0, mc.fontRenderer, this.width / 2 - 154, this.height - 29 - 23, 148, 18);
         search.setCanLoseFocus(true);
         buttonConflict = new GuiButton(2906, this.width / 2 - 155 + 160, this.height - 29 - 24, 150 / 2, 20, translate("options.showConflicts"));
         buttonNone = new GuiButton(2907, this.width / 2 - 155 + 160 + 80, this.height - 29 - 24, 150 / 2, 20, translate("options.showNone"));
@@ -273,8 +273,8 @@ public class GuiNewControls extends GuiControls {
             }
             KeyBinding.resetKeyBindingArrayAndHash();
         } else if(button.id < 100 && button instanceof GuiOptionButton) {
-            this.options.setOptionValue(((GuiOptionButton) button).returnEnumOptions(), 1);
-            button.displayString = this.options.getKeyBinding(GameSettings.Options.getEnumOptions(button.id));
+            this.options.setOptionValue(((GuiOptionButton) button).getOption(), 1);
+            button.displayString = this.options.getKeyBinding(GameSettings.Options.byOrdinal(button.id));
         } else if(button.id == 2906) {
             none = false;
             buttonNone.displayString = translate("options.showNone");
@@ -335,7 +335,7 @@ public class GuiNewControls extends GuiControls {
             superSuperMouseClicked(mouseX, mouseY, mouseButton);
         }
         search.mouseClicked(mouseX, mouseY, mouseButton);
-        if(mouseButton == 1 && mouseX >= search.xPosition && mouseX < search.xPosition + search.width && mouseY >= search.yPosition && mouseY < search.yPosition + search.height) {
+        if(mouseButton == 1 && mouseX >= search.x && mouseX < search.x + search.width && mouseY >= search.y && mouseY < search.y + search.height) {
             search.setText("");
         }
     }
@@ -425,8 +425,8 @@ public class GuiNewControls extends GuiControls {
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         this.drawDefaultBackground();
         this.keyBindingList.drawScreen(mouseX, mouseY, partialTicks);
-        this.drawCenteredString(this.fontRendererObj, this.screenTitle, this.width / 2, 8, 16777215);
-        this.drawCenteredString(this.fontRendererObj, translate("options.search"), this.width / 2 - (155 / 2), this.height - 29 - 39, 16777215);
+        this.drawCenteredString(this.fontRenderer, this.screenTitle, this.width / 2, 8, 16777215);
+        this.drawCenteredString(this.fontRenderer, translate("options.search"), this.width / 2 - (155 / 2), this.height - 29 - 39, 16777215);
         boolean flag = false;
         
         for(KeyBinding keybinding : this.options.keyBindings) {
@@ -450,7 +450,7 @@ public class GuiNewControls extends GuiControls {
     
     public void superSuperDrawScreen(int mouseX, int mouseY, float partialTicks) {
         for(GuiButton aButtonList : this.buttonList) {
-            aButtonList.func_191745_a(this.mc, mouseX, mouseY, partialTicks);
+            aButtonList.drawButton(this.mc, mouseX, mouseY, partialTicks);
         }
         
         for(GuiLabel aLabelList : this.labelList) {

--- a/src/main/java/us/getfluxed/controlsearch/client/gui/GuiNewKeyBindingList.java
+++ b/src/main/java/us/getfluxed/controlsearch/client/gui/GuiNewKeyBindingList.java
@@ -47,7 +47,7 @@ public class GuiNewKeyBindingList extends GuiKeyBindingList {
                 }
             }
             
-            int j = mcIn.fontRendererObj.getStringWidth(I18n.format(keybinding.getKeyDescription()));
+            int j = mcIn.fontRenderer.getStringWidth(I18n.format(keybinding.getKeyDescription()));
             
             if(j > this.maxListLabelWidth) {
                 this.maxListLabelWidth = j;
@@ -71,7 +71,7 @@ public class GuiNewKeyBindingList extends GuiKeyBindingList {
     }
     
     protected int getScrollBarX() {
-        return super.getScrollBarX() + 35;
+        return GuiNewKeyBindingList.this.mc.currentScreen.width - 50;
     }
     
     /**
@@ -89,16 +89,18 @@ public class GuiNewKeyBindingList extends GuiKeyBindingList {
         
         public CategoryEntry(String name) {
             this.labelText = I18n.format(name);
-            this.labelWidth = GuiNewKeyBindingList.this.mc.fontRendererObj.getStringWidth(this.labelText);
+            this.labelWidth = GuiNewKeyBindingList.this.mc.fontRenderer.getStringWidth(this.labelText);
         }
-        
+
+
         @Override
-        public void func_192633_a(int p_192633_1_, int p_192633_2_, int p_192633_3_, float p_192633_4_) {
+        public void updatePosition(int i, int i1, int i2, float v) {
+
         }
-        
+
         @Override
-        public void func_192634_a(int slotIndex, int x, int y, int listWidth, int slotHeight, int mouseX, int mouseY, boolean isSelected, float p_192634_9_) {
-            GuiNewKeyBindingList.this.mc.fontRendererObj.drawString(this.labelText, GuiNewKeyBindingList.this.mc.currentScreen.width / 2 - this.labelWidth / 2, y + slotHeight - GuiNewKeyBindingList.this.mc.fontRendererObj.FONT_HEIGHT - 1, 16777215);
+        public void drawEntry(int slotIndex, int x, int y, int listWidth, int slotHeight, int mouseX, int mouseY, boolean isSelected, float p_192634_9_) {
+            GuiNewKeyBindingList.this.mc.fontRenderer.drawString(this.labelText, GuiNewKeyBindingList.this.mc.currentScreen.width / 2 - this.labelWidth / 2, y + slotHeight - GuiNewKeyBindingList.this.mc.fontRenderer.FONT_HEIGHT - 1, 16777215);
         }
         
         /**
@@ -139,21 +141,23 @@ public class GuiNewKeyBindingList extends GuiKeyBindingList {
         }
         
         @Override
-        public void func_192633_a(int p_192633_1_, int p_192633_2_, int p_192633_3_, float p_192633_4_) {
+        public void updatePosition(int p_192633_1_, int p_192633_2_, int p_192633_3_, float p_192633_4_) {
         }
         
         @Override
-        public void func_192634_a(int slotIndex, int x, int y, int listWidth, int slotHeight, int mouseX, int mouseY, boolean isSelected, float p_192634_9_) {
+        public void drawEntry(int slotIndex, int x, int y, int listWidth, int slotHeight, int mouseX, int mouseY, boolean isSelected, float p_192634_9_) {
             boolean flag = GuiNewKeyBindingList.this.controlsScreen.buttonId == this.keybinding;
-            GuiNewKeyBindingList.this.mc.fontRendererObj.drawString(this.keyDesc, x + 90 - GuiNewKeyBindingList.this.maxListLabelWidth, y + slotHeight / 2 - GuiNewKeyBindingList.this.mc.fontRendererObj.FONT_HEIGHT / 2, 16777215);
+            int halfScreen = GuiNewKeyBindingList.this.mc.currentScreen.width / 2;
+            boolean extendFlag = GuiNewKeyBindingList.this.mc.fontRenderer.getStringWidth(this.keyDesc) > halfScreen;
+            GuiNewKeyBindingList.this.mc.fontRenderer.drawString(this.keyDesc, Math.max(x + 90 - GuiNewKeyBindingList.this.maxListLabelWidth, 20), y + slotHeight / 2 - GuiNewKeyBindingList.this.mc.fontRenderer.FONT_HEIGHT / 2, 16777215);
             //            GuiNewKeyBindingList.this.mc.fontRendererObj.drawString(String.format("(%s)", I18n.format(keybinding.getKeyCategory())), x - 45 - GuiNewKeyBindingList.this.maxListLabelWidth, y + slotHeight / 2 - GuiNewKeyBindingList.this.mc.fontRendererObj.FONT_HEIGHT / 2, 16777215);
             btnReset.visible = !keybinding.isSetToDefaultValue();
-            this.btnReset.xPosition = x + 210;
-            this.btnReset.yPosition = y;
+            this.btnReset.x = halfScreen + 110;
+            this.btnReset.y = y;
             this.btnReset.enabled = !this.keybinding.isSetToDefaultValue();
             
-            this.btnChangeKeyBinding.xPosition = x + 105;
-            this.btnChangeKeyBinding.yPosition = y;
+            this.btnChangeKeyBinding.x = halfScreen + 5;
+            this.btnChangeKeyBinding.y = y;
             this.btnChangeKeyBinding.displayString = this.keybinding.getDisplayName();
             
             boolean flag1 = false;
@@ -173,12 +177,15 @@ public class GuiNewKeyBindingList extends GuiKeyBindingList {
             } else if(flag1) {
                 this.btnChangeKeyBinding.displayString = (keyCodeModifierConflict ? TextFormatting.GOLD : TextFormatting.RED) + this.btnChangeKeyBinding.displayString;
             }
-            this.btnChangeKeyBinding.func_191745_a(GuiNewKeyBindingList.this.mc, mouseX, mouseY, p_192634_9_);
-            this.btnReset.func_191745_a(GuiNewKeyBindingList.this.mc, mouseX, mouseY, p_192634_9_);
+            this.btnChangeKeyBinding.drawButton(GuiNewKeyBindingList.this.mc, mouseX, mouseY, p_192634_9_);
+            this.btnReset.drawButton(GuiNewKeyBindingList.this.mc, mouseX, mouseY, p_192634_9_);
             //            if(mouseX >= x + 90 - GuiNewKeyBindingList.this.maxListLabelWidth && mouseX <= x + listWidth) {
             if(mouseY >= y && mouseY <= y + slotHeight) {
-                mc.fontRendererObj.drawString(I18n.format(keybinding.getKeyCategory()), mouseX + 10, mouseY, 0xFFFFFF);
-            }
+                if(extendFlag) {
+                    mc.fontRenderer.drawString(I18n.format(keybinding.getKeyCategory()) + ": " + this.keyDesc, mouseX + 10, mouseY, 0xFFFFFF);
+                }else{
+                    mc.fontRenderer.drawString(I18n.format(keybinding.getKeyCategory()), mouseX + 10, mouseY, 0xFFFFFF);
+                }            }
             //            }
             
             

--- a/src/main/java/us/getfluxed/controlsearch/client/gui/GuiNewKeyBindingList.java
+++ b/src/main/java/us/getfluxed/controlsearch/client/gui/GuiNewKeyBindingList.java
@@ -71,7 +71,7 @@ public class GuiNewKeyBindingList extends GuiKeyBindingList {
     }
     
     protected int getScrollBarX() {
-        return GuiNewKeyBindingList.this.mc.currentScreen.width - 50;
+        return GuiNewKeyBindingList.this.mc.currentScreen.width - 20;
     }
     
     /**


### PR DESCRIPTION
The key bind setting screen always has serval minor problems. After I found all short descriptions were pushed out of the window by a long text and the scroll bar somehow disappear under windowed mode, I decide to make a PR.
I have read #74 and decide using hovering text for long text displaying like that:
![2023-01-25_13 51 32](https://user-images.githubusercontent.com/11038263/214492509-193c616e-7bf2-444e-9093-e3ee515b7129.png)
Not much key description or translation key is longer than the window width, so I didn't bother to do the text wrapping thing.