### PR TITLE
Extend German translation

### DIFF
--- a/src/main/resources/assets/controlling/lang/de_DE.lang
+++ b/src/main/resources/assets/controlling/lang/de_DE.lang
@@ -1,6 +1,13 @@
 options.search=Suchen
 options.showAll=Alle anzeigen
-options.showConflicts=Konflikte anzeigen
-options.showNone=Unbenutze anzeigen
+options.showConflicts=Konfl. anzeig.
+options.showNone=Unben. anzeig.
 options.availableKeys=Verfügbare Tasten
 options.sort=Sortieren nach
+options.category=Kategorie
+options.key=Taste
+options.sortNone=(nichts)
+options.sortAZ=A->Z
+options.sortZA=Z->A
+options.toggleFree=Freie Tasten anzeig.
+options.confirmReset=Möchtest du wirklich zurücksetzen?


### PR DESCRIPTION
I added missing German translations and shortened some existing ones that were unreadable due to the buttons being too small.
I think it would be better to increase the button sizes, as I believe many (also more recent) versions are affected by this too?

Either way, I believe these changes could be applied to more recent branches too. Would you want me to open PRs for all of them (or maybe only specific supported ones)?