### PR TITLE
Use Forge's `clientSideOnly` feature

### DIFF
--- a/forge/src/main/java/com/blamejared/controlling/Controlling.java
+++ b/forge/src/main/java/com/blamejared/controlling/Controlling.java
@@ -2,24 +2,12 @@ package com.blamejared.controlling;
 
 import com.blamejared.controlling.events.ClientEventHandler;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.IExtensionPoint;
-import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
-import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 
 @Mod("controlling")
 public class Controlling {
     
     public Controlling() {
-        
-        ModLoadingContext.get()
-                .registerExtensionPoint(IExtensionPoint.DisplayTest.class, () -> new IExtensionPoint.DisplayTest(() -> IExtensionPoint.DisplayTest.IGNORESERVERONLY, (remote, isServer) -> true));
-        FMLJavaModLoadingContext.get().getModEventBus().addListener(this::init);
-    }
-    
-    private void init(final FMLClientSetupEvent event) {
-        
         MinecraftForge.EVENT_BUS.register(new ClientEventHandler());
     }
     

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -2,6 +2,7 @@ modLoader = "javafml"
 loaderVersion = "${FORGE_LOADER}"
 issueTrackerURL = "${GIT_REPO}/issues"
 license = "MIT"
+clientSideOnly = true
 [[mods]]
 modId = "${MODID}"
 updateJSONURL = "https://updates.blamejared.com/get?n=${MODID}&gv=${MINECRAFT}&ml=forge"


### PR DESCRIPTION
This feature sets an appropriate DisplayTest and ignores the mod on dedicated servers, handling the sided loading for you so that you don't need to worry about it.