### PR TITLE
Polish translation update

### DIFF
--- a/common/src/main/resources/assets/controlling/lang/pl_pl.json
+++ b/common/src/main/resources/assets/controlling/lang/pl_pl.json
@@ -3,10 +3,12 @@
   "options.showConflicts": "Konfliktujące",
   "options.showNone": "Nieprzypisane",
   "options.availableKeys": "Dostępne klawisze",
-  "options.sort": "Sortow.",
-  "options.sortNone": "Brak",
+  "options.sort": "Sortuj",
+  "options.sortNone": "Nie",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",
+  "options.sortKeyAZ": "Klawisz A->Z",
+  "options.sortKeyZA": "Klawisz Z->A",
   "options.toggleFree": "Wolne",
   "options.confirmReset": "Na pewno?"
 }


### PR DESCRIPTION
In this pull request, I updated the Polish translation to include all the changes to the source translation strings made since my last update of the Polish translation 2 years ago in 4da9d458abdd51011e1006f77d8b8b0e1c2531c3. This mainly includes the changes from commit 3f0fadcc96406983429bff92500b81738c7c2d20, but I also took the opportunity to improve one or two of the existing text strings.

If this translation gets accepted in the main branch, may I ask you to backport it to the older Minecraft versions you still support (if any)? I'm particularly referring to the most popular versions among players, such as 1.21.1, 1.20.1, or 1.19.2.