### PR TITLE
Removed all unused translation keys from lang files

### DIFF
--- a/common/src/main/resources/assets/controlling/lang/de_de.json
+++ b/common/src/main/resources/assets/controlling/lang/de_de.json
@@ -4,8 +4,6 @@
   "options.showNone": "Unben. anzeig.",
   "options.availableKeys": "Verfügbare Tasten",
   "options.sort": "Sortieren nach",
-  "options.category": "Kategorie",
-  "options.key": "Taste",
   "options.sortNone": "(nichts)",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/en_ca.json
+++ b/common/src/main/resources/assets/controlling/lang/en_ca.json
@@ -4,8 +4,6 @@
   "options.showNone": "Show Unbound",
   "options.availableKeys": "Available Keys",
   "options.sort": "Sort",
-  "options.category": "Category",
-  "options.key": "Key",
   "options.sortNone": "None",
   "options.sortAZ": "A->Zed",
   "options.sortZA": "Zed->A",

--- a/common/src/main/resources/assets/controlling/lang/en_pt.json
+++ b/common/src/main/resources/assets/controlling/lang/en_pt.json
@@ -4,8 +4,6 @@
   "options.showNone": "Untethered",
   "options.availableKeys": "Untethered Keys",
   "options.sort": "Filter",
-  "options.category": "Factions",
-  "options.key": "Key",
   "options.sortNone": "Naught",
   "options.sortAZ": "Bow->Stern",
   "options.sortZA": "Stern->Bow",

--- a/common/src/main/resources/assets/controlling/lang/en_ud.json
+++ b/common/src/main/resources/assets/controlling/lang/en_ud.json
@@ -1,13 +1,11 @@
 {
-  "options.category": "ʎɹoᵷǝʇɐƆ",
-  "options.key": "ʎǝꞰ",
-  "options.showNone": "punoqu∩ ʍoɥS",
-  "options.showConflicts": "sʇɔılɟuoƆ ʍoɥS",
   "options.showAll": "ꞁꞁⱯ ʍoɥS",
+  "options.showConflicts": "sʇɔılɟuoƆ ʍoɥS",
+  "options.showNone": "punoqu∩ ʍoɥS",
+  "options.availableKeys": "sʎǝꞰ ǝlqɐlᴉɐʌ∀",
   "options.sort": "ʇɹoS",
   "options.sortNone": "ǝuoN",
   "options.sortAZ": "Z<-Ɐ",
   "options.sortZA": "Ɐ<-Z",
-  "options.availableKeys": "sʎǝꞰ ǝlqɐlᴉɐʌ∀",
   "options.confirmReset": "¡ʇǝsǝɹ ɯɹıɟuoɔ oʇ ʞɔᴉꞁƆ"
 }

--- a/common/src/main/resources/assets/controlling/lang/en_us.json
+++ b/common/src/main/resources/assets/controlling/lang/en_us.json
@@ -4,8 +4,6 @@
   "options.showNone": "Show Unbound",
   "options.availableKeys": "Available Keys",
   "options.sort": "Sort",
-  "options.category": "Category",
-  "options.key": "Key",
   "options.sortNone": "None",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/es_es.json
+++ b/common/src/main/resources/assets/controlling/lang/es_es.json
@@ -4,8 +4,6 @@
   "options.showNone": "No asignados",
   "options.availableKeys": "Teclas Disponibles",
   "options.sort": "Ordenar",
-  "options.category": "Categoría",
-  "options.key": "Tecla",
   "options.sortNone": "No",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/fi_fi.json
+++ b/common/src/main/resources/assets/controlling/lang/fi_fi.json
@@ -4,8 +4,6 @@
   "options.showNone": "Näytä määrittämättömät",
   "options.availableKeys": "Vapaat näppäimet",
   "options.sort": "Lajittele",
-  "options.category": "Kategoria",
-  "options.key": "Näppäin",
   "options.sortNone": "Älä lajittele",
   "options.sortAZ": "A->Ö",
   "options.sortZA": "Ö->A",

--- a/common/src/main/resources/assets/controlling/lang/fr_fr.json
+++ b/common/src/main/resources/assets/controlling/lang/fr_fr.json
@@ -4,8 +4,6 @@
   "options.showNone": "Non-liées",
   "options.availableKeys": "Touches disp.",
   "options.sort": "Tri",
-  "options.category": "Catégorie",
-  "options.key": "Touche",
   "options.sortNone": "Aucun",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/hi_in.json
+++ b/common/src/main/resources/assets/controlling/lang/hi_in.json
@@ -4,8 +4,6 @@
   "options.showNone": "अनबाउंड दिखाएं",
   "options.availableKeys": "उपलब्ध कुंजियाँ",
   "options.sort": "छंटाई",
-  "options.category": "श्रेणी",
-  "options.key": "चाभी",
   "options.sortNone": "कोई भी नहीं",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/it_it.json
+++ b/common/src/main/resources/assets/controlling/lang/it_it.json
@@ -4,8 +4,6 @@
   "options.showNone": "Vedi mancanti",
   "options.availableKeys": "Tasti disponibili",
   "options.sort": "Ordine",
-  "options.category": "Categoria",
-  "options.key": "Tasto",
   "options.sortNone": "no",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/ja_jp.json
+++ b/common/src/main/resources/assets/controlling/lang/ja_jp.json
@@ -4,8 +4,6 @@
   "options.showNone": "未割り当てを表示",
   "options.availableKeys": "利用可能なキー",
   "options.sort": "並べ替え",
-  "options.category": "カテゴリー",
-  "options.key": "キー",
   "options.toggleFree": "トグルフリー",
   "options.confirmReset": "クリックしてリセットを承諾します！"
 }

--- a/common/src/main/resources/assets/controlling/lang/kk_kz.json
+++ b/common/src/main/resources/assets/controlling/lang/kk_kz.json
@@ -4,8 +4,6 @@
   "options.showNone": "Байланыспағанды көрсету",
   "options.availableKeys": "Қолжетімді перне",
   "options.sort": "Сұрыптау",
-  "options.category": "Санат",
-  "options.key": "Перне",
   "options.sortNone": "Еш",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/ko_kr.json
+++ b/common/src/main/resources/assets/controlling/lang/ko_kr.json
@@ -4,8 +4,6 @@
   "options.showNone": "미지정 표시",
   "options.availableKeys": "사용 가능한 키",
   "options.sort": "정렬",
-  "options.category": "범주",
-  "options.key": "키",
   "options.sortNone": "없음",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/lzh.json
+++ b/common/src/main/resources/assets/controlling/lang/lzh.json
@@ -4,8 +4,6 @@
   "options.showNone": "顯未绑定",
   "options.availableKeys": "可用按鍵",
   "options.sort": "序",
-  "options.category": "類",
-  "options.key": "鍵",
   "options.sortNone": "無",
   "options.sortAZ": "A至Z",
   "options.sortZA": "Z至A",

--- a/common/src/main/resources/assets/controlling/lang/nl_nl.json
+++ b/common/src/main/resources/assets/controlling/lang/nl_nl.json
@@ -4,8 +4,6 @@
   "options.showNone": "Toon niet-toegewezen",
   "options.availableKeys": "Beschikbare toetsen",
   "options.sort": "Sorteren",
-  "options.category": "Categorie",
-  "options.key": "Toets",
   "options.sortNone": "Geen",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/pl_pl.json
+++ b/common/src/main/resources/assets/controlling/lang/pl_pl.json
@@ -4,8 +4,6 @@
   "options.showNone": "Nieprzypisane",
   "options.availableKeys": "Dostępne klawisze",
   "options.sort": "Sortow.",
-  "options.category": "Kategoria",
-  "options.key": "Klawisz",
   "options.sortNone": "Brak",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/pt_br.json
+++ b/common/src/main/resources/assets/controlling/lang/pt_br.json
@@ -4,8 +4,6 @@
   "options.showNone": "Mostrar Desv.",
   "options.availableKeys": "Teclas disponíveis",
   "options.sort": "Ordem",
-  "options.category": "Categoria",
-  "options.key": "Tecla",
   "options.sortNone": "Nenhuma",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/ru_ru.json
+++ b/common/src/main/resources/assets/controlling/lang/ru_ru.json
@@ -4,8 +4,6 @@
   "options.showNone": "Показать не привязанные",
   "options.availableKeys": "Доступные клавиши",
   "options.sort": "Сортировать",
-  "options.category": "Категория",
-  "options.key": "Клавиша",
   "options.sortNone": "Ничего",
   "options.sortAZ": "А->Я",
   "options.sortZA": "Я->А",

--- a/common/src/main/resources/assets/controlling/lang/ta_in.json
+++ b/common/src/main/resources/assets/controlling/lang/ta_in.json
@@ -4,8 +4,6 @@
   "options.showNone": "வரம்பற்றதைக் காட்டு",
   "options.availableKeys": "இலவச விசைகள்",
   "options.sort": "வகைபடுத்து",
-  "options.category": "வகை",
-  "options.key": "விசை",
   "options.sortNone": "எதுவுமில்லை",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/tr_tr.json
+++ b/common/src/main/resources/assets/controlling/lang/tr_tr.json
@@ -4,8 +4,6 @@
   "options.showNone": "Atanmamışları Göster",
   "options.availableKeys": "Boşta Anahtarlar",
   "options.sort": "Sırala",
-  "options.category": "Kategori",
-  "options.key": "Anahtar",
   "options.sortNone": "Hiç",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/uk_ua.json
+++ b/common/src/main/resources/assets/controlling/lang/uk_ua.json
@@ -4,8 +4,6 @@
   "options.showNone": "Не прив'язані",
   "options.availableKeys": "Доступні клавіші",
   "options.sort": "Сортувати",
-  "options.category": "Категорія",
-  "options.key": "Клавіша",
   "options.sortNone": "Ні",
   "options.sortAZ": "А->Я",
   "options.sortZA": "Я->А",

--- a/common/src/main/resources/assets/controlling/lang/zh_cn.json
+++ b/common/src/main/resources/assets/controlling/lang/zh_cn.json
@@ -4,8 +4,6 @@
   "options.showNone": "显示未绑定键位",
   "options.availableKeys": "可用的快捷键",
   "options.sort": "排序",
-  "options.category": "分类",
-  "options.key": "键位",
   "options.sortNone": "无",
   "options.sortAZ": "A->Z",
   "options.sortZA": "Z->A",

--- a/common/src/main/resources/assets/controlling/lang/zh_hk.json
+++ b/common/src/main/resources/assets/controlling/lang/zh_hk.json
@@ -4,8 +4,6 @@
   "options.showNone": "顯示未綁定",
   "options.availableKeys": "可用按鍵",
   "options.sort": "排序",
-  "options.category": "分類",
-  "options.key": "按鍵",
   "options.sortNone": "無",
   "options.sortAZ": "A 至 Z",
   "options.sortZA": "Z 至 A",

--- a/common/src/main/resources/assets/controlling/lang/zh_tw.json
+++ b/common/src/main/resources/assets/controlling/lang/zh_tw.json
@@ -4,8 +4,6 @@
   "options.showNone": "顯示未綁定",
   "options.availableKeys": "可用按鍵",
   "options.sort": "排序",
-  "options.category": "分類",
-  "options.key": "按鍵",
   "options.sortNone": "無",
   "options.sortAZ": "A 至 Z",
   "options.sortZA": "Z 至 A",


### PR DESCRIPTION
Since the integration with Searchables (commit 29dcb917e54ea0d58338f177342e28eb75bef8b1), the following translation keys are no longer in use: `options.category` and `options.key`. While the associated code has been removed, these keys have been left behind, waiting for better times, which, I'm afraid, will never come, as the Searchables mod simply does the job better.

To make life easier for other translators and reduce bloat, I propose removing the unused keys mentioned earlier from all translation files.