### PR TITLE
feat: exact matching

### DIFF
--- a/common/src/main/java/com/blamejared/controlling/ControllingConstants.java
+++ b/common/src/main/java/com/blamejared/controlling/ControllingConstants.java
@@ -10,6 +10,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 public class ControllingConstants {
     
@@ -22,32 +23,52 @@ public class ControllingConstants {
     public static final MutableComponent COMPONENT_OPTIONS_SORT = Component.translatable("options.sort");
     public static final MutableComponent COMPONENT_OPTIONS_TOGGLE_FREE = Component.translatable("options.toggleFree");
     public static final MutableComponent COMPONENT_OPTIONS_AVAILABLE_KEYS = Component.translatable("options.availableKeys");
+    public static final MutableComponent COMPONENT_OPTIONS_EXACT_MATCH = Component.translatable("options.exactMatch");
+    public static final MutableComponent COMPONENT_OPTIONS_FUZZY_MATCH = Component.translatable("options.fuzzyMatch");
     
     
-    public static final SearchableType<KeyBindsList.Entry> SEARCHABLE_KEYBINDINGS = new SearchableType.Builder<KeyBindsList.Entry>()
-            .component(SearchableComponent.create("category", entry -> {
-                if(entry instanceof ICategoryEntry cat) {
-                    return Optional.of(cat.category().label().getString());
-                } else if(entry instanceof IKeyEntry key) {
-                    return Optional.of(key.categoryName().getString());
-                }
-                return Optional.empty();
-            }))
-            .component(SearchableComponent.create("key", entry -> {
-                if(entry instanceof IKeyEntry key && !key.getKey().isUnbound()) {
-                    return Optional.of(key.getKey().getTranslatedKeyMessage().getString());
-                }
-                return Optional.empty();
-            }))
-            .defaultComponent(SearchableComponent.create("name", entry -> {
-                if(entry instanceof IKeyEntry key) {
-                    return Optional.of(key.getName().getString());
-                } else if(entry instanceof IInputEntry input) {
-                    return Optional.of(input.getInput().getName());
-                }
-                return Optional.empty();
-            }))
+    private static final Function<KeyBindsList.Entry, Optional<String>> KEYBINDING_CATEGORY = entry -> {
+        if(entry instanceof ICategoryEntry cat) {
+            return Optional.of(cat.category().label().getString());
+        } else if(entry instanceof IKeyEntry key) {
+            return Optional.of(key.categoryName().getString());
+        }
+        return Optional.empty();
+    };
+    private static final Function<KeyBindsList.Entry, Optional<String>> KEYBINDING_KEY = entry -> {
+        if(entry instanceof IKeyEntry key && !key.getKey().isUnbound()) {
+            return Optional.of(key.getKey().getTranslatedKeyMessage().getString());
+        }
+        return Optional.empty();
+    };
+    private static final Function<KeyBindsList.Entry, Optional<String>> KEYBINDING_NAME = entry -> {
+        if(entry instanceof IKeyEntry key) {
+            return Optional.of(key.getName().getString());
+        } else if(entry instanceof IInputEntry input) {
+            return Optional.of(input.getInput().getName());
+        }
+        return Optional.empty();
+    };
+
+    public static final SearchableType<KeyBindsList.Entry> SEARCHABLE_KEYBINDINGS = createSearchableKeybindings(false);
+    public static final SearchableType<KeyBindsList.Entry> EXACT_SEARCHABLE_KEYBINDINGS = createSearchableKeybindings(true);
+
+    private static SearchableType<KeyBindsList.Entry> createSearchableKeybindings(boolean exactMatch) {
+        return new SearchableType.Builder<KeyBindsList.Entry>()
+            .component(createSearchableComponent("category", KEYBINDING_CATEGORY, exactMatch))
+            .component(createSearchableComponent("key", KEYBINDING_KEY, exactMatch))
+            .defaultComponent(createSearchableComponent("name", KEYBINDING_NAME, exactMatch))
             .build();
+    }
+
+    private static SearchableComponent<KeyBindsList.Entry> createSearchableComponent(String key, Function<KeyBindsList.Entry, Optional<String>> value, boolean exactMatch) {
+        if(exactMatch) {
+            return SearchableComponent.create(key, value, (entry, search) -> value.apply(entry)
+                    .map(componentValue -> componentValue.equalsIgnoreCase(search))
+                    .orElse(false));
+        }
+        return SearchableComponent.create(key, value);
+    }
     
     
 }

--- a/common/src/main/java/com/blamejared/controlling/client/NewKeyBindsScreen.java
+++ b/common/src/main/java/com/blamejared/controlling/client/NewKeyBindsScreen.java
@@ -38,11 +38,11 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
     private AutoCompletingEditBox<KeyBindsList.Entry> search;
     private DisplayMode displayMode;
     private SortOrder sortOrder = SortOrder.NONE;
-    private Button buttonNone;
-    private Button buttonConflicting;
+    private Button buttonDisplayMode;
     private Button buttonSort;
     private final DisplayableBoolean confirmingReset = new DisplayableBoolean(false, ControllingConstants.COMPONENT_OPTIONS_CONFIRM_RESET, ControllingConstants.COMPONENT_CONTROLS_RESET_ALL);
     private boolean showFree;
+    private boolean exactMatch;
     private Supplier<NewKeyBindsList> newKeyList;
     private Supplier<FreeKeysList> freeKeyList;
     
@@ -91,8 +91,13 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
     @Override
     protected void addFooter() {
         
-        int btnWidth = Button.DEFAULT_WIDTH / 2 - 1;
+        int controlsWidth = 340;
+        int controlSpacing = 4;
+        int btnWidth = (controlsWidth - controlSpacing * 3) / 4;
+        int actionSpacing = 8;
+        int actionBtnWidth = (controlsWidth - actionSpacing) / 2;
         this.resetButton(Button.builder(confirmingReset.currentDisplay(), PRESS_RESET)
+                .width(actionBtnWidth)
                 .build());
         resetButton().active = canReset();
         
@@ -104,31 +109,32 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
                 .size(btnWidth, Button.DEFAULT_HEIGHT)
                 .build();
         
-        this.buttonNone = Button.builder(ControllingConstants.COMPONENT_OPTIONS_SHOW_NONE, PRESS_NONE)
+        this.buttonDisplayMode = Button.builder(displayModeDisplay(), PRESS_DISPLAY_MODE)
                 .size(btnWidth, Button.DEFAULT_HEIGHT)
                 .build();
         
-        this.buttonConflicting = Button.builder(ControllingConstants.COMPONENT_OPTIONS_SHOW_CONFLICTS, PRESS_CONFLICTING)
+        Button buttonExactMatch = Button.builder(exactMatch ?
+                        ControllingConstants.COMPONENT_OPTIONS_EXACT_MATCH
+                        : ControllingConstants.COMPONENT_OPTIONS_FUZZY_MATCH, PRESS_EXACT_MATCH)
                 .size(btnWidth, Button.DEFAULT_HEIGHT)
                 .build();
-        
         
         GridLayout grid = this.layout.addToFooter(new GridLayout());
         grid.rowSpacing(4);
-        grid.columnSpacing(8);
-        GridLayout.RowHelper rowHelper = grid.createRowHelper(2);
-        LinearLayout topLeft = rowHelper.addChild(LinearLayout.horizontal());
-        topLeft.spacing(4);
-        topLeft.addChild(toggleFreeButton);
-        topLeft.addChild(this.buttonSort);
-        
-        LinearLayout topRight = rowHelper.addChild(LinearLayout.horizontal());
-        topRight.spacing(4);
-        topRight.addChild(this.buttonNone);
-        topRight.addChild(this.buttonConflicting);
-        
-        rowHelper.addChild(resetButton());
-        rowHelper.addChild(Button.builder(CommonComponents.GUI_DONE, _ -> this.onClose()).build());
+        GridLayout.RowHelper rowHelper = grid.createRowHelper(1);
+        LinearLayout filters = rowHelper.addChild(LinearLayout.horizontal());
+        filters.spacing(controlSpacing);
+        filters.addChild(toggleFreeButton);
+        filters.addChild(this.buttonSort);
+        filters.addChild(this.buttonDisplayMode);
+        filters.addChild(buttonExactMatch);
+
+        LinearLayout actions = rowHelper.addChild(LinearLayout.horizontal());
+        actions.spacing(actionSpacing);
+        actions.addChild(resetButton());
+        actions.addChild(Button.builder(CommonComponents.GUI_DONE, _ -> this.onClose())
+                .width(actionBtnWidth)
+                .build());
     }
     
     @Override
@@ -184,7 +190,8 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
                 list.sort(sortOrder);
             };
         }
-        List<KeyBindsList.Entry> entries = ControllingConstants.SEARCHABLE_KEYBINDINGS.filterEntries(list.getAllEntries(), lastSearch, extraPredicate);
+        List<KeyBindsList.Entry> entries = (exactMatch ? ControllingConstants.EXACT_SEARCHABLE_KEYBINDINGS : ControllingConstants.SEARCHABLE_KEYBINDINGS)
+                .filterEntries(list.getAllEntries(), lastSearch, extraPredicate);
         for(KeyBindsList.Entry entry : entries) {
             list.addEntryInternal(entry);
         }
@@ -284,6 +291,14 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
         }
         return false;
     }
+
+    private Component displayModeDisplay() {
+        return switch(displayMode) {
+            case ALL -> ControllingConstants.COMPONENT_OPTIONS_SHOW_ALL;
+            case NONE -> ControllingConstants.COMPONENT_OPTIONS_SHOW_NONE;
+            case CONFLICTING -> ControllingConstants.COMPONENT_OPTIONS_SHOW_CONFLICTS;
+        };
+    }
     
     private final Button.OnPress PRESS_RESET = btn -> {
         NewKeyBindsScreen screen = NewKeyBindsScreen.this;
@@ -299,15 +314,13 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
         btn.setMessage(confirmingReset.currentDisplay());
     };
     
-    private final Button.OnPress PRESS_NONE = _ -> {
-        if(displayMode == DisplayMode.NONE) {
-            buttonNone.setMessage(ControllingConstants.COMPONENT_OPTIONS_SHOW_NONE);
-            displayMode = DisplayMode.ALL;
-        } else {
-            displayMode = DisplayMode.NONE;
-            buttonNone.setMessage(ControllingConstants.COMPONENT_OPTIONS_SHOW_ALL);
-            buttonConflicting.setMessage(ControllingConstants.COMPONENT_OPTIONS_SHOW_CONFLICTS);
-        }
+    private final Button.OnPress PRESS_DISPLAY_MODE = btn -> {
+        displayMode = switch(displayMode) {
+            case ALL -> DisplayMode.CONFLICTING;
+            case CONFLICTING -> DisplayMode.NONE;
+            case NONE -> DisplayMode.ALL;
+        };
+        btn.setMessage(displayModeDisplay());
         filterKeys();
     };
     
@@ -317,31 +330,17 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
         filterKeys();
     };
     
-    private final Button.OnPress PRESS_CONFLICTING = _ -> {
-        if(displayMode == DisplayMode.CONFLICTING) {
-            buttonConflicting.setMessage(ControllingConstants.COMPONENT_OPTIONS_SHOW_CONFLICTS);
-            displayMode = DisplayMode.ALL;
-        } else {
-            displayMode = DisplayMode.CONFLICTING;
-            buttonConflicting.setMessage(ControllingConstants.COMPONENT_OPTIONS_SHOW_ALL);
-            buttonNone.setMessage(ControllingConstants.COMPONENT_OPTIONS_SHOW_NONE);
-        }
-        filterKeys();
-    };
-    
     private final Button.OnPress PRESS_FREE = _ -> {
         removeWidget(getKeyBindsList());
         if(showFree) {
             buttonSort.active = true;
-            buttonNone.active = true;
-            buttonConflicting.active = true;
+            buttonDisplayMode.active = true;
             resetButton().active = canReset(); // Fixes
             setKeyBindsList(newKeyList.get());
         } else {
             freeKeyList.get().recalculate();
             buttonSort.active = false;
-            buttonNone.active = false;
-            buttonConflicting.active = false;
+            buttonDisplayMode.active = false;
             resetButton().active = false;
             setKeyBindsList(freeKeyList.get());
         }
@@ -351,4 +350,13 @@ public class NewKeyBindsScreen extends KeyBindsScreen {
         showFree = !showFree;
     };
     
+    private final Button.OnPress PRESS_EXACT_MATCH = btn -> {
+        exactMatch = !exactMatch;
+        btn.setMessage(exactMatch ?
+                ControllingConstants.COMPONENT_OPTIONS_EXACT_MATCH
+                : ControllingConstants.COMPONENT_OPTIONS_FUZZY_MATCH
+        );
+        filterKeys();
+    };
+
 }

--- a/common/src/main/resources/assets/controlling/lang/en_us.json
+++ b/common/src/main/resources/assets/controlling/lang/en_us.json
@@ -10,5 +10,7 @@
   "options.sortKeyAZ": "Key A->Z",
   "options.sortKeyZA": "Key Z->A",
   "options.toggleFree": "Toggle Free",
-  "options.confirmReset": "Confirm?"
+  "options.confirmReset": "Confirm?",
+  "options.exactMatch": "Search: Exact",
+  "options.fuzzyMatch": "Search: Fuzzy"
 }


### PR DESCRIPTION
This adds a way to do exact matching in search so that searching key:C no longer shows stuff like `CTRL + <whatever>`

To make the menu stuff fit well I had to combine show unbound and show conflicts into one since they dont work together anyways I think that's fine but feel free to comment on it